### PR TITLE
Fixes python build failures in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,9 @@ RUN apt-get update \
         swig \
         python-pip \
         python-dev \
+        python-enchant \
+        python-numpy \
+        python-scipy \
         libssl-dev \
         liblzma-dev \
         libevent1-dev \

--- a/Dockerfile
+++ b/Dockerfile
@@ -46,6 +46,8 @@ RUN /seed/bin/install_javascript_dependencies.sh
 ### Install python requirements
 COPY ./requirements.txt /seed/requirements.txt
 COPY ./requirements/*.txt /seed/requirements/
+# next line needed to avoid breakage in sphinx?
+RUN pip install imagesize configparser enum
 RUN pip install -r requirements/local.txt
 
 ### Copy over the remaining part of the SEED application

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -6,8 +6,3 @@ django-debug-toolbar==1.4
 # numpy
 # scipy
 ipython
-
-# ?? prevents docker build failure in sphinx
-imagesize
-enum
-configparser

--- a/requirements/local.txt
+++ b/requirements/local.txt
@@ -3,6 +3,11 @@
 django-debug-toolbar==1.4
 
 # required for migration scripts (for new data model) at the moment
-numpy
-scipy
+# numpy
+# scipy
 ipython
+
+# ?? prevents docker build failure in sphinx
+imagesize
+enum
+configparser


### PR DESCRIPTION
#### Any background context you want to provide?

Trying to build out a dev instance with Docker, I ran into a couple of build failures.

#### What's this PR do?

- Having some trouble building scipy/numpy with a `no lapack/blas resources found` error. Solution: just throw in pre-built versions with apt-get instead, since I understand these to be transitional dependencies from comments and `pip` install seems to be brittle.

- Sphinx build fails with no module found for enchant, enum, configparser, and imagesize. Add `enchant` via apt since `pip` was failing for reasons I wasn't grokking. Add the rest to `pip` requirements.

#### How should this be manually tested?

`docker-compose build --no-cache && docker-compose up`

#### What are the relevant tickets?

n/a

#### Screenshots (if appropriate)

n/a

#### Definition of Done:
- [ ] Is there appropriate test coverage? (e.g. ChefSpec, Mocha/Chai, Python, etc.)
- [ ] Does this PR require a Selenium test? (e.g. Browser-specific bugs or complicated UI bugs)
- [ ] Does this PR require a regression test? All fixes require a regression test.
- [ ] Does this add new dependencies? If so, does PIP, npm, bower requirements need to be updated?